### PR TITLE
Fix broken code samples for button sizes

### DIFF
--- a/src/docs/data/button.ts
+++ b/src/docs/data/button.ts
@@ -1,14 +1,11 @@
-//button
-
 export const buttonSize = `
 import { Button } from 'kampsy-ui';
 
 <div class="w-full flex flex-wrap gap-4 justify-between">
-	<Button size="sm">upload</Button>
+	<Button size="tiny">upload</Button>
 	<Button>upload</Button>
-	<Button size="lg">upload</Button>
+	<Button size="large">upload</Button>
 </div>`;
-
 
 export const buttonTypes = `
 import { Button } from 'kampsy-ui';
@@ -88,25 +85,28 @@ export const buttonRounded = `
 import { Button } from 'kampsy-ui';
 
 <div class="w-full flex flex-wrap gap-4 justify-between">
-	<Button size="sm" type="secondary" rounded>upload</Button>
+	<Button size="tiny" type="secondary" rounded>upload</Button>
+	<Button size="small" type="secondary" rounded>upload</Button>
 	<Button type="secondary" rounded>upload</Button>
-	<Button size="lg" type="secondary" rounded>upload</Button>
+	<Button size="large" type="secondary" rounded>upload</Button>
 </div>`;
 
 export const buttonLoading= `
 import { Button } from 'kampsy-ui';
 
 <div class="w-full flex flex-wrap gap-4 justify-between">
-	<Button size="sm" loading>upload</Button>
+	<Button size="tiny" loading>upload</Button>
+	<Button size="small" loading>upload</Button>
 	<Button loading>upload</Button>
-	<Button size="lg" loading>upload</Button>
+	<Button size="large" loading>upload</Button>
 </div>`;
 
 export const buttonDisabled= `
 import { Button } from 'kampsy-ui';
 
 <div class="w-full flex flex-wrap gap-4 justify-between">
-	<Button size="sm" disabled>upload</Button>
+	<Button size="tiny" disabled>upload</Button>
+	<Button size="small" disabled>upload</Button>
 	<Button disabled>upload</Button>
-	<Button size="lg" disabled>upload</Button>
+	<Button size="large" disabled>upload</Button>
 </div>`;

--- a/src/docs/data/button.ts
+++ b/src/docs/data/button.ts
@@ -3,6 +3,7 @@ import { Button } from 'kampsy-ui';
 
 <div class="w-full flex flex-wrap gap-4 justify-between">
 	<Button size="tiny">upload</Button>
+	<Button size="small">upload</Button>
 	<Button>upload</Button>
 	<Button size="large">upload</Button>
 </div>`;
@@ -91,7 +92,7 @@ import { Button } from 'kampsy-ui';
 	<Button size="large" type="secondary" rounded>upload</Button>
 </div>`;
 
-export const buttonLoading= `
+export const buttonLoading = `
 import { Button } from 'kampsy-ui';
 
 <div class="w-full flex flex-wrap gap-4 justify-between">
@@ -101,7 +102,7 @@ import { Button } from 'kampsy-ui';
 	<Button size="large" loading>upload</Button>
 </div>`;
 
-export const buttonDisabled= `
+export const buttonDisabled = `
 import { Button } from 'kampsy-ui';
 
 <div class="w-full flex flex-wrap gap-4 justify-between">

--- a/src/routes/button/+page.svelte
+++ b/src/routes/button/+page.svelte
@@ -68,7 +68,7 @@
 			{#snippet demo()}
 				<Button size="tiny">upload</Button>
 				<Button size="small">upload</Button>
-				<Button size="medium">upload</Button>
+				<Button>upload</Button>
 				<Button size="large">upload</Button>
 			{/snippet}
 			{@render demoAndCode(demo, buttonSize)}
@@ -114,7 +114,7 @@
 		<p
 			class="mt-2 xl:mt-4 first-letter:capitalize text-kui-light-gray-900 dark:text-kui-dark-gray-900 text-[16px] font-normal leading-6"
 		>
-		Icon-only buttons should include the {@render roundedCode('shape')} prop and an
+			Icon-only buttons should include the {@render roundedCode('shape')} prop and an
 			{@render roundedCode('aria-label')}.
 		</p>
 		<div class="mt-4 xl:mt-7">
@@ -131,7 +131,7 @@
 					</div>
 				</Button>
 
-				<Button aria-label="Upload" shape="square" size="medium">
+				<Button aria-label="Upload" shape="square">
 					<div class="w-[16px] h-[16px]">
 						<ArrowUp />
 					</div>
@@ -155,7 +155,7 @@
 					</div>
 				</Button>
 
-				<Button aria-label="Upload" shape="circle" size="medium">
+				<Button aria-label="Upload" shape="circle">
 					<div class="w-[16px] h-[16px]">
 						<ArrowUp />
 					</div>
@@ -211,7 +211,7 @@
 			{#snippet demo()}
 				<Button size="tiny" type="secondary" rounded>upload</Button>
 				<Button size="small" type="secondary" rounded>upload</Button>
-				<Button size="medium" type="secondary" rounded>upload</Button>
+				<Button type="secondary" rounded>upload</Button>
 				<Button size="large" type="secondary" rounded>upload</Button>
 			{/snippet}
 			{@render demoAndCode(demo, buttonRounded)}
@@ -232,7 +232,7 @@
 			{#snippet demo()}
 				<Button size="tiny" loading>upload</Button>
 				<Button size="small" loading>upload</Button>
-				<Button size="medium" loading>upload</Button>
+				<Button loading>upload</Button>
 				<Button size="large" loading>upload</Button>
 			{/snippet}
 			{@render demoAndCode(demo, buttonLoading)}
@@ -252,7 +252,7 @@
 			{#snippet demo()}
 				<Button size="tiny" disabled>upload</Button>
 				<Button size="small" disabled>upload</Button>
-				<Button size="medium" disabled>upload</Button>
+				<Button disabled>upload</Button>
 				<Button size="large" disabled>upload</Button>
 			{/snippet}
 			{@render demoAndCode(demo, buttonDisabled)}

--- a/src/routes/button/+page.svelte
+++ b/src/routes/button/+page.svelte
@@ -66,8 +66,9 @@
 		</p>
 		<div class="mt-4 xl:mt-7">
 			{#snippet demo()}
+				<Button size="tiny">upload</Button>
 				<Button size="small">upload</Button>
-				<Button>upload</Button>
+				<Button size="medium">upload</Button>
 				<Button size="large">upload</Button>
 			{/snippet}
 			{@render demoAndCode(demo, buttonSize)}
@@ -130,7 +131,7 @@
 					</div>
 				</Button>
 
-				<Button aria-label="Upload" shape="square">
+				<Button aria-label="Upload" shape="square" size="medium">
 					<div class="w-[16px] h-[16px]">
 						<ArrowUp />
 					</div>
@@ -154,7 +155,7 @@
 					</div>
 				</Button>
 
-				<Button aria-label="Upload" shape="circle">
+				<Button aria-label="Upload" shape="circle" size="medium">
 					<div class="w-[16px] h-[16px]">
 						<ArrowUp />
 					</div>
@@ -208,8 +209,9 @@
 		<!--The example with code snippet-->
 		<div class="mt-4 xl:mt-7">
 			{#snippet demo()}
+				<Button size="tiny" type="secondary" rounded>upload</Button>
 				<Button size="small" type="secondary" rounded>upload</Button>
-				<Button type="secondary" rounded>upload</Button>
+				<Button size="medium" type="secondary" rounded>upload</Button>
 				<Button size="large" type="secondary" rounded>upload</Button>
 			{/snippet}
 			{@render demoAndCode(demo, buttonRounded)}
@@ -228,8 +230,9 @@
 		<!--The example with code snippet-->
 		<div class="mt-4 xl:mt-7">
 			{#snippet demo()}
+				<Button size="tiny" loading>upload</Button>
 				<Button size="small" loading>upload</Button>
-				<Button loading>upload</Button>
+				<Button size="medium" loading>upload</Button>
 				<Button size="large" loading>upload</Button>
 			{/snippet}
 			{@render demoAndCode(demo, buttonLoading)}
@@ -247,8 +250,9 @@
 		<!--The example with code snippet-->
 		<div class="mt-4 xl:mt-7">
 			{#snippet demo()}
+				<Button size="tiny" disabled>upload</Button>
 				<Button size="small" disabled>upload</Button>
-				<Button disabled>upload</Button>
+				<Button size="medium" disabled>upload</Button>
 				<Button size="large" disabled>upload</Button>
 			{/snippet}
 			{@render demoAndCode(demo, buttonDisabled)}


### PR DESCRIPTION
## Quick Glance

- Fix broken [Button](https://ui.kampsy.xyz/button) code samples using `sm` and `lg` instead of `small` and `large`
  Fixes #10. 
- Add code samples for `tiny`

## Description

Fixes broken code samples in the documentation for the `Button` component.

> [!NOTE]
> This pull request was partially authored by [GitHub Copilot Workspace](https://copilot-workspace.githubnext.com/Wombosvideo/kampsy-ui/issues/1?shareId=e3d747d3-0779-4682-a198-a2a78f52a3f3). The tool helped identify the non-obvious occurences of the `size` property.