### PR TITLE
Bind input `value` to bindable `value` Input property

### DIFF
--- a/src/lib/input/input.svelte
+++ b/src/lib/input/input.svelte
@@ -159,7 +159,7 @@
 			<div class="w-full h-full {inputContClass}">
 				<input
 					{type}
-					{value}
+					bind:value
 					aria-labelledby={araiLabelledBy}
 					{spellcheck}
 					{placeholder}


### PR DESCRIPTION
## Quick Glance

- Change `{value}` to `bind:value` in `src/lib/input/input.svelte`.
  Fixes #12